### PR TITLE
lame.git is deprecated - URL has changed

### DIFF
--- a/converter/get-source.sh
+++ b/converter/get-source.sh
@@ -32,7 +32,7 @@ rm -rf $SRCDIR
 mkdir -p $SRCDIR
 
 (cd $SRCDIR; git clone git://source.ffmpeg.org/ffmpeg.git; cd ffmpeg; git checkout "$FFMPEG_VER"; git cherry-pick fe84f70819d6f5aab3c4823290e0d32b99d6de78)
-(cd $SRCDIR; git clone https://github.com/rbrito/deprecated-lame-mirror; cd lame; git checkout "$LAME_VER")
+(cd $SRCDIR; git clone https://github.com/rbrito/deprecated-lame-mirror.git; cd lame; git checkout "$LAME_VER")
 (cd $SRCDIR; git clone git://git.xiph.org/ogg.git; cd ogg; git checkout "$OGG_VER")
 (cd $SRCDIR; git clone git://git.xiph.org/vorbis.git; cd vorbis; git checkout "$VORBIS_VER")
 (cd $SRCDIR; git clone git://git.xiph.org/opus.git; cd opus; git checkout "$OPUS_VER")

--- a/converter/get-source.sh
+++ b/converter/get-source.sh
@@ -32,7 +32,7 @@ rm -rf $SRCDIR
 mkdir -p $SRCDIR
 
 (cd $SRCDIR; git clone git://source.ffmpeg.org/ffmpeg.git; cd ffmpeg; git checkout "$FFMPEG_VER"; git cherry-pick fe84f70819d6f5aab3c4823290e0d32b99d6de78)
-(cd $SRCDIR; git clone https://github.com/rbrito/lame.git; cd lame; git checkout "$LAME_VER")
+(cd $SRCDIR; git clone https://github.com/rbrito/deprecated-lame-mirror; cd lame; git checkout "$LAME_VER")
 (cd $SRCDIR; git clone git://git.xiph.org/ogg.git; cd ogg; git checkout "$OGG_VER")
 (cd $SRCDIR; git clone git://git.xiph.org/vorbis.git; cd vorbis; git checkout "$VORBIS_VER")
 (cd $SRCDIR; git clone git://git.xiph.org/opus.git; cd opus; git checkout "$OPUS_VER")

--- a/converter/get-source.sh
+++ b/converter/get-source.sh
@@ -6,7 +6,7 @@ BASEDIR=$(dirname "$0")
 SRCDIR="$BASEDIR/src"
 
 FFMPEG_VER="n4.0"
-LAME_VER="RELEASE__3_99_5"
+LAME_VER="lame3_100_with_psymodel_v3_99_5"
 OGG_VER="v1.3.3"
 VORBIS_VER="8ef0f8058854b2ef55d2d42bbe84487a9aadae12" 
 OPUS_VER="v1.2.1"


### PR DESCRIPTION
"[DEPRECATED] Old, Semi-official mirror of the CVS repository of the LAME MP3 encoder."
the URL is read-only, and can be accessed at the path i have put into the script.