### PR TITLE
Fix typo in converter/get-source.sh for fetching numa lib

### DIFF
--- a/converter/get-source.sh
+++ b/converter/get-source.sh
@@ -49,7 +49,7 @@ mkdir -p ${SRCDIR}
 (cd ${SRCDIR} && git clone https://salsa.debian.org/gstreamer-team/orc.git orc && cd orc && git checkout "${ORC_VER}")
 (cd ${SRCDIR} && git clone https://github.com/Distrotech/libtheora.git theora && cd theora && git checkout "${THEORA_VER}")
 (cd ${SRCDIR} && git clone https://github.com/opencor/bzip2.git bzip2 && cd bzip2 && git checkout "${BZIP2_VER}")
-(cd ${SRCDIR} && git clone https://github.com/numactl/numactl.git numa && d numa && git checkout "${NUMA_VER}")
+(cd ${SRCDIR} && git clone https://github.com/numactl/numactl.git numa && cd numa && git checkout "${NUMA_VER}")
 (cd ${SRCDIR} && git clone https://aomedia.googlesource.com/aom aom && cd aom && git checkout "${AOM_VER}")
 
 for lib in ${LIBS}; do


### PR DESCRIPTION
"cd numa" was mistyped "d numa", causing the subsequent "git checkout" to be skipped; numa would therefore be built against master rather than the defined tag.