### PR TITLE
add Microsoft Edge Linux version support

### DIFF
--- a/app/native-autoinstall.js
+++ b/app/native-autoinstall.js
@@ -168,7 +168,7 @@ function DarwinUninstall() {
 
 function LinuxInstall() {
 	var { mode, config } = ParseModeConfig();
-	var { chrome: chromeManifest, firefox: firefoxManifest } = GetManifests(config);
+	var { chrome: chromeManifest, firefox: firefoxManifest, edge: edgeManifest} = GetManifests(config);
 	var manifests;
 	if(mode=="user") 
 		manifests = [{
@@ -179,6 +179,9 @@ function LinuxInstall() {
 		},{
 			file: process.env.HOME+"/.config/chromium/NativeMessagingHosts/"+config.id+".json",
 			manifest: JSON.stringify(chromeManifest,null,4),
+		},{
+			file: process.env.HOME+"/.config/microsoft-edge/NativeMessagingHosts/"+config.id+".json",
+			manifest: JSON.stringify(edgeManifest,null,4),
 		}];
 	else {
 		manifests = [{
@@ -190,6 +193,9 @@ function LinuxInstall() {
 		},{
 			file: "/etc/chromium/native-messaging-hosts/"+config.id+".json",
 			manifest: JSON.stringify(chromeManifest,null,4),
+		},{
+			file: "/etc/opt/edge/native-messaging-hosts/"+config.id+".json",
+			manifest: JSON.stringify(edgeManifest,null,4),
 		}];
 		if(os.arch()=="x64")
 			try {
@@ -221,13 +227,15 @@ function LinuxUninstall() {
 		manifests = [
 			process.env.HOME+"/.mozilla/native-messaging-hosts/"+config.id+".json",
 			process.env.HOME+"/.config/google-chrome/NativeMessagingHosts/"+config.id+".json",
-			process.env.HOME+"/.config/chromium/NativeMessagingHosts/"+config.id+".json"
+			process.env.HOME+"/.config/chromium/NativeMessagingHosts/"+config.id+".json",
+			process.env.HOME+"/.config/microsoft-edge/NativeMessagingHosts/"+config.id+".json"
 		];
 	else
 		manifests = [
 			"/usr/lib/mozilla/native-messaging-hosts/"+config.id+".json",
 			"/etc/opt/chrome/native-messaging-hosts/"+config.id+".json",
-			"/etc/chromium/native-messaging-hosts/"+config.id+".json"
+			"/etc/chromium/native-messaging-hosts/"+config.id+".json",
+			"/etc/opt/edge/native-messaging-hosts/"+config.id+".json"
 		];
 	try {
 		manifests.forEach((file)=>{

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -917,6 +917,9 @@ gulp.task('setup-local-linux',(callback) => {
 			fs.outputFile(
 				process.env.HOME+"/.config/vivaldi/NativeMessagingHosts/"+config.id+".json",
 				JSON.stringify(vivaldiManifest,null,4),"utf8"),
+			fs.outputFile(
+				process.env.HOME+"/.config/microsoft-edge/NativeMessagingHosts/"+config.id+".json",
+				JSON.stringify(vivaldiManifest,null,4),"utf8"),
 		])
 		.then(()=>{
 			return fs.copy("node_modules/opn/xdg-open","bin/xdg-open");
@@ -933,7 +936,8 @@ gulp.task('unsetup-local-linux',(callback) => {
 		fs.remove(process.env.HOME+"/.config/google-chrome/NativeMessagingHosts/"+config.id+".json"),
 		fs.remove(process.env.HOME+"/.config/chromium/NativeMessagingHosts/"+config.id+".json"),
 		fs.remove(process.env.HOME+"/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/"+config.id+".json"),
-		fs.remove(process.env.HOME+"/.config/vivaldi/NativeMessagingHosts/"+config.id+".json")
+		fs.remove(process.env.HOME+"/.config/vivaldi/NativeMessagingHosts/"+config.id+".json"),
+		fs.remove(process.env.HOME+"/.config/microsoft-edge/NativeMessagingHosts/"+config.id+".json")
 	])
 	.then(()=>{
 		callback();


### PR DESCRIPTION
As Microsoft Edge officially have a Linux version, this provides the support for the extension on Microsoft Edge Linux version. As tested, it works as intended:
![Ekrankopio de 2022-02-20 23-58-15](https://user-images.githubusercontent.com/15316889/154851660-99a2e12a-ca1a-469c-b2d1-108058384e7f.png)

